### PR TITLE
removendo "Outras Remunerações Temporárias"

### DIFF
--- a/src/output_test/expected/expected_01_2020.json
+++ b/src/output_test/expected/expected_01_2020.json
@@ -43,12 +43,6 @@
                         "tipoReceita": "O"
                     },
                     {
-                        "categoria": "contracheque",
-                        "item": "Outras Remunerações Temporárias",
-                        "valor": 7880.49,
-                        "tipoReceita": "O"
-                    },
-                    {
                         "natureza": "D",
                         "categoria": "contracheque",
                         "item": "Contribuição Previdenciária",

--- a/src/parser.py
+++ b/src/parser.py
@@ -15,7 +15,6 @@ HEADERS = {
         "Gratificação Natalina": 8,
         "Férias (1/3 constitucional)": 9,
         "Abono de Permanência": 10,
-        "Outras Remunerações Temporárias": 11,
         "Contribuição Previdenciária": 14,
         "Imposto de Renda": 15,
         "Retenção por Teto Constitucional": 16,


### PR DESCRIPTION
Essa coluna, presente na planilha de contracheques, é na realidade um somatório de outras remunerações presentes na planilha de indenizações.